### PR TITLE
Add basic access auth support

### DIFF
--- a/lmt-srv/app-lmt.js
+++ b/lmt-srv/app-lmt.js
@@ -43,6 +43,14 @@ const request_logger = require('koa-pino-logger')
 /** the unique app object that will listen on a given port */
 const app = new Koa();
 
+if (process.env.hasOwnProperty('HTTP_USER') && process.env.hasOwnProperty('HTTP_PASSWORD')) {
+  const auth = require('koa-basic-auth');
+  app.use(auth({
+    name: process.env.HTTP_USER,
+    pass: process.env.HTTP_PASSWORD
+  }));
+}
+
 //assume production unless specified in .env
 process.env.NODE_ENV = (undefined == process.env.NODE_ENV) ? 'production' : process.env.NODE_ENV
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,14 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
     "bindings": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
@@ -472,6 +480,15 @@
         "statuses": "^1.5.0",
         "type-is": "^1.6.16",
         "vary": "^1.1.2"
+      }
+    },
+    "koa-basic-auth": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/koa-basic-auth/-/koa-basic-auth-4.0.0.tgz",
+      "integrity": "sha512-eV1sGVAizDuFWNpY43VF3Z1ND4PotQZB/igxHNrcJXzXw+Flmj8Uv+4hP9LyNXyvqLJz/X5bmXeMu84AAGD9Jw==",
+      "requires": {
+        "basic-auth": "^2.0.0",
+        "tsscmp": "^1.0.6"
       }
     },
     "koa-compose": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "ecstatic": "^4.1.4",
     "escape-html": "^1.0.3",
     "koa": "^2.12.0",
+    "koa-basic-auth": "^4.0.0",
     "koa-mount": "^4.0.0",
     "koa-pino-logger": "^3.0.0",
     "koa-router": "^9.1.0",


### PR DESCRIPTION
If HTTP_USER and HTTP_PASSWORD environment vars are set, then http authentication is enabled. Usage example:

```
HTTP_USER=foo HTTP_PASSWORD=bar npm start
```